### PR TITLE
we always need type info for bools, because it is NOT safe to…

### DIFF
--- a/copy_this/modules/oxps/modulesconfig/core/oxpsmodulesconfigconfigexport.php
+++ b/copy_this/modules/oxps/modulesconfig/core/oxpsmodulesconfigconfigexport.php
@@ -365,7 +365,7 @@ class oxpsModulesConfigConfigExport extends OxpsConfigCommandBase
         } else {
             // default type
             $typeInfoNeeded = true;
-            if ($sVarType == 'str' || $sVarType == 'bool') {
+            if ($sVarType == 'str') {
                 $typeInfoNeeded = false;
                 if (substr($sVarName, 0, 2) === "bl") {
                     if ($sVarType !== 'bool') {


### PR DESCRIPTION
… rely on that all bool var names start with "bl"