### PR TITLE
changed default value for Configuration Directory

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -40,7 +40,7 @@ $aModule = [
         'en' => 'Tools to export, backup and import OXID eShop modules configuration data.',
     ],
     'thumbnail'   => 'out/pictures/oxpsmodulesconfig.png',
-    'version'     => '4.0.17',
+    'version'     => '5.0.0',
     'author'      => 'OXID Professional Services',
     'url'         => 'http://www.oxid-esales.com',
     'email'       => 'info@oxid-esales.com',
@@ -56,6 +56,6 @@ $aModule = [
         'onDeactivate' => 'OxidProfessionalServices\\ModulesConfig\\Core\\Module::onDeactivate',
     ],
     'settings' => [
-        [ 'group' => 'main', 'name' => 'OXPS_MODULESCONFIG_SETTING_CONFIGURATION_DIRECTORY', 'type' => 'str', 'value' => 'configurations' ]
+        [ 'group' => 'main', 'name' => 'OXPS_MODULESCONFIG_SETTING_CONFIGURATION_DIRECTORY', 'type' => 'str', 'value' => '../../../../configurations' ]
     ]
 ];


### PR DESCRIPTION
Initial the default value for the configuration directory is set to the path where the module is getting installed. However it would be better to have the directory outside the modules Folder. This change will expect the configurations folder on the same directory level where the sources folder is located.