### PR TITLE
Feature generate oxserial after import

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -65,8 +65,8 @@ class ImportCommand extends Command
             $utilsObject = \oxUtilsObject::getInstance();
             $utilsObject->setModuleVar('aModuleFiles', null);
         }
-        $oConfigExport = oxNew(ConfigImport::class, $output, $input);
-        $oConfigExport->executeConsoleCommand();
+        $oConfigImport = oxNew(ConfigImport::class, $output, $input);
+        $oConfigImport->executeConsoleCommand();
     }
 
 }

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -63,7 +63,7 @@ class ImportCommand extends Command
 
             //workaround for issue in oxid see https://github.com/OXID-eSales/oxideshop_ce/pull/413
             $utilsObject = \oxUtilsObject::getInstance();
-            $utilsObject->setModuleVar('aModuleFiles',null);
+            $utilsObject->setModuleVar('aModuleFiles', null);
         }
         $oConfigExport = oxNew(ConfigImport::class, $output, $input);
         $oConfigExport->executeConsoleCommand();

--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -29,6 +29,7 @@ namespace OxidProfessionalServices\ModulesConfig\Core;
 use OxidEsales\Eshop\Core\DatabaseProvider;
 use OxidCommunity\ModuleInternals\Core\ModuleStateFixer;
 use OxidProfessionalServices\OxidConsole\Core\ShopConfig;
+use OxidEsales\Eshop\Application\Controller\Admin\ShopLicense;
 use OxidEsales\Eshop\Core\Registry;
 
 /**
@@ -80,6 +81,7 @@ class ConfigImport extends CommandBase
             $aMetaConfig = $this->readConfigValues($this->getShopsConfigFileName());
             $aShops = $aMetaConfig['shops'];
             $this->runShopConfigImportForAllShops($aShops);
+            $this->generateOxserial();
             $this->output->writeLn("done");
         } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
             $this->output->writeLn("Could not parse a YAML File.");
@@ -123,6 +125,19 @@ class ConfigImport extends CommandBase
         $this->output->writeLn("Importing config for shop $sShop");
 
         $this->importConfigValues($aResult);
+    }
+
+    /**
+     * Generates OXSERIAL stored in oxshops table from aSerials (from oxconfig table)
+     */
+    protected function generateOxserial()
+    {
+        $licence = oxNew(ShopLicense::class);
+        Registry::getSession()->setVariable('malladmin', true);
+
+        $licence->updateShopSerial();
+
+        $this->output->writeLn('generated OXSERIAL');
     }
 
     /**

--- a/configurations/oxpsconfigmodulesettings.php
+++ b/configurations/oxpsconfigmodulesettings.php
@@ -20,6 +20,7 @@ return array(
         'sParcelService',
         'blUseContentCaching',
         'iTimeToUpdatePrices',
+        'OXSERIAL', // generated single serial number from all aSerials, will be generated during import
         //timestamp to check if cron jobs must be executed
         'iFailedOnlineCallsCount',
         //sometimes good to not exclude this to have value be restored to 0 on import, but on the other hand
@@ -38,7 +39,6 @@ return array(
     //environment specific fields
     'envFields'                     => array(
         'aSerials', //oxid serial numbers. Must be different on live system.
-        'OXSERIAL', // generated single serial number from all aSerials
         'sMallShopURL',
         'sMallSSLShopURL',
         'blCheckTemplates', //sets if templates should be recompililed on change good in develop env


### PR DESCRIPTION
There are two fields related to the serial in the config-export at the moment:
1. `aSerials` in the `oxconfig` table, which holds multiple license keys which you can also enter in the OXID backend
2. `OXSERIAL` in the `oxshops` table, which is generated after you enter the `aSerials` in the OXID backend

The current workflow to add new license keys is:
1. Add license keys manually in OXID backend
2. Create new config export
3. Add related changes to git

Sometimes we want to add the license key directly into the `yaml` file and roll that change out without opening the OXID backend. Therefore we need a mechanism to generate the `OXSERIAL` inside the `config:import` command.

----
I fixed some non-related stuff (whitespace and a variable-name), to get only the related diff take a look at this commit: https://github.com/OXIDprojects/oxid_modules_config/commit/11f4c3335804da7d2210b87f4cea3f2281ae513f

You can test this already by using `"oxid-professional-services/oxid-modules-config": "dev-feature-generate-oxserial-after-import"` in your `composer.json` or directly by calling:
```
composer require oxid-professional-services/oxid-modules-config dev-feature-generate-oxserial-after-import
```