### PR TITLE
Add moduleinternals version 3 to supported versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "symfony/yaml": "^2.0 || ^3.0",
     "oxid-esales/oxideshop-ce": "^v6.0.0",
-    "oxid-community/moduleinternals": "^2.0 || ^1.5"
+    "oxid-community/moduleinternals": "^3.0 || ^2.0 || ^1.5"
   },
   "extra": {
     "oxideshop": {


### PR DESCRIPTION
It is not possible to install the module with OXID Version 6.2, because it's requires an old version of module-internals:
```
abez@4d77e2e88b86:/var/www/oxideshop$ composer require oxid-professional-services/oxid-modules-config ^6.0@beta
./composer.json has been updated                                                    
Loading composer repositories with package information     
Updating dependencies (including require-dev)     
Your requirements could not be resolved to an installable set of packages.
                                      
  Problem 1
    - oxid-professional-services/oxid-modules-config 6.0.0-beta5 requires oxid-community/moduleinternals ^2.0 || ^1.5 -> satisfiable by oxid-community/moduleinternals[1.5, 1.5.1, 1.5.2, 1.
5.2-beta1, 2.0.0, 2.0.0-alpha1, 2.0.0-alpha2, 2.0.0-alpha3, 2.0.0-alpha4, 2.0.0-alpha5, 2.0.0-alpha6, 2.0.0-alpha7, 2.0.0-alpha8, 2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4, 2.0.0-
beta5, 2.0.0-beta6, 2.0.0-rc1, 2.0.0-rc2, 2.0.0-rc3] but these conflict with your requirements or minimum-stability.
    - oxid-professional-services/oxid-modules-config 6.0.0-beta4 requires oxid-community/moduleinternals ^2.0 || ^1.5 -> satisfiable by oxid-community/moduleinternals[1.5, 1.5.1, 1.5.2, 1.
5.2-beta1, 2.0.0, 2.0.0-alpha1, 2.0.0-alpha2, 2.0.0-alpha3, 2.0.0-alpha4, 2.0.0-alpha5, 2.0.0-alpha6, 2.0.0-alpha7, 2.0.0-alpha8, 2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4, 2.0.0-
beta5, 2.0.0-beta6, 2.0.0-rc1, 2.0.0-rc2, 2.0.0-rc3] but these conflict with your requirements or minimum-stability.
    - oxid-professional-services/oxid-modules-config 6.0.0-beta3 requires oxid-community/moduleinternals ^2.0 || ^1.5 -> satisfiable by oxid-community/moduleinternals[1.5, 1.5.1, 1.5.2, 1.
5.2-beta1, 2.0.0, 2.0.0-alpha1, 2.0.0-alpha2, 2.0.0-alpha3, 2.0.0-alpha4, 2.0.0-alpha5, 2.0.0-alpha6, 2.0.0-alpha7, 2.0.0-alpha8, 2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4, 2.0.0-
beta5, 2.0.0-beta6, 2.0.0-rc1, 2.0.0-rc2, 2.0.0-rc3] but these conflict with your requirements or minimum-stability.
    - oxid-professional-services/oxid-modules-config 6.0.0-beta2 requires oxid-community/moduleinternals ^2.0 || ^1.5 -> satisfiable by oxid-community/moduleinternals[1.5, 1.5.1, 1.5.2, 1.
5.2-beta1, 2.0.0, 2.0.0-alpha1, 2.0.0-alpha2, 2.0.0-alpha3, 2.0.0-alpha4, 2.0.0-alpha5, 2.0.0-alpha6, 2.0.0-alpha7, 2.0.0-alpha8, 2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4, 2.0.0-
beta5, 2.0.0-beta6, 2.0.0-rc1, 2.0.0-rc2, 2.0.0-rc3] but these conflict with your requirements or minimum-stability.
    - oxid-professional-services/oxid-modules-config 6.0.0-beta requires oxid-community/moduleinternals ^2.0 || ^1.5 -> satisfiable by oxid-community/moduleinternals[1.5, 1.5.1, 1.5.2, 1.5
.2-beta1, 2.0.0, 2.0.0-alpha1, 2.0.0-alpha2, 2.0.0-alpha3, 2.0.0-alpha4, 2.0.0-alpha5, 2.0.0-alpha6, 2.0.0-alpha7, 2.0.0-alpha8, 2.0.0-beta1, 2.0.0-beta2, 2.0.0-beta3, 2.0.0-beta4, 2.0.0-b
eta5, 2.0.0-beta6, 2.0.0-rc1, 2.0.0-rc2, 2.0.0-rc3] but these conflict with your requirements or minimum-stability.
    - Installation request for oxid-professional-services/oxid-modules-config ^6.0@beta -> satisfiable by oxid-professional-services/oxid-modules-config[6.0.0-beta, 6.0.0-beta2, 6.0.0-beta
3, 6.0.0-beta4, 6.0.0-beta5].


Installation failed, reverting ./composer.json to its original content.
abez@4d77e2e88b86:/var/www/oxideshop$ 
```

After changing the version number in my projects composer.json it worked:
```
abez@4d77e2e88b86:/var/www/oxideshop$ grep oxid-community/moduleinternals composer.json 
    "oxid-community/moduleinternals": "dev-master as 2.0.0",
```
The config export worked also, so I guess, we should just add the new version to the `composer.json` of this package.