### PR TITLE
Bugfix skipped subshops in 6.2 do not work

### DIFF
--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -256,6 +256,7 @@ class ConfigImport extends CommandBase
         //doing so does not having any known effect.
         $shop = $oConfig->getActiveShop();
         $shop->setShopId($sShopId);
+        $oConfig->setShopId($sShopId);
         //set the global config onject in oxid 6.1 
         $shop->setConfig($oConfig);
         //we need a fresh instance here because

--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -262,7 +262,7 @@ class ConfigImport extends CommandBase
         $shop = $oConfig->getActiveShop();
         $shop->setShopId($sShopId);
         $oConfig->setShopId($sShopId);
-        //set the global config onject in oxid 6.1
+        //set the global config object in oxid 6.1
         $shop->setConfig($oConfig);
         //we need a fresh instance here because
         //shopId calculator is private


### PR DESCRIPTION
I faced this issue today:

![image](https://user-images.githubusercontent.com/1001186/74543172-304e5880-4f45-11ea-8b3b-39c403911146.png)

We're using an EE 6.2-rc with two shops with ids 1 and 6. Shop-ID 1 works as expected, but shop-ID 6 throws this error. After adding the line from cf281a4af64085ff8fc7bda7804fbe31ee374960 it worked.

I fixed some code style violations and a typo in a comment alongside. I have no idea how to reproduce the behavior at the moment, it's also hard to write a test for this since this is a EE feature and I guess we will get some sort of license/auth problems. If we find a way to solve the license problem I can try to add a test case for this. I have already some EE related integration tests with multiple shops in private projects.