### PR TITLE
Update ConfigImport.php

### DIFF
--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -322,8 +322,10 @@ class ConfigImport extends CommandBase
                     //    "[NOTE] {$sModuleId} current version is $cv"
                     //);
                 }
-                $disabledModulesBeforeImport[$sModuleId] = 'disabledByUpdate';
-                $oModuleStateFixer->deactivate($oModule);
+                if($oModule->isActive()) {
+                    $disabledModulesBeforeImport[$sModuleId] = 'disabledByUpdate';
+                    $oModuleStateFixer->deactivate($oModule);
+                }
             }
         }
 


### PR DESCRIPTION
only deactivate module if it is activated. We can run into the case, that a not activated module is updated to a newer version. Then we run into a ModuleSetupException. See

https://github.com/OXID-eSales/oxideshop_ce/blob/e454b1de3a675ba023bc4e2c76eb626a0ac1e794/source/Internal/Framework/Module/Setup/Service/ModuleActivationService.php#L121