### PR TITLE
Update ConfigImport

### DIFF
--- a/Controller/Admin/ShopMain.php
+++ b/Controller/Admin/ShopMain.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This Software is the property of OXID eSales and is protected
+ * by copyright law - it is NOT Freeware.
+ *
+ * Any unauthorized use of this software without a valid license key
+ * is a violation of the license agreement and will be prosecuted by
+ * civil and criminal law.
+ *
+ * @category      module
+ * @author        OXID Professional services
+ * @link          http://www.oxid-esales.com
+ * @copyright (C) OXID eSales AG 2003-2020
+ */
+
+namespace OxidProfessionalServices\ModulesConfig\Controller\Admin;
+
+use OxidEsales\Eshop\Application\Controller\Admin\ShopMain as ShopMainCore;
+
+/**
+ * ShopMain.
+ */
+class ShopMain extends ShopMainCore
+{
+    /**
+     * Check if Shop can be created.
+     *
+     * @param string                                   $shopId
+     * @param \OxidEsales\Eshop\Application\Model\Shop $shop
+     *
+     * @return bool
+     */
+    public function canCreateShop($shopId, $shop)
+    {
+        return parent::canCreateShop($shopId, $shop);
+    }
+
+    /**
+     * Update shop information in DB and Config.
+     *
+     * @param \OxidEsales\Eshop\Core\Config            $config
+     * @param \OxidEsales\Eshop\Application\Model\Shop $shop
+     * @param string                                   $shopId
+     */
+    public function updateShopInformation($config, $shop, $shopId)
+    {
+        parent::updateShopInformation($config, $shop, $shopId);
+    }
+}

--- a/Controller/Admin/ShopMain.php
+++ b/Controller/Admin/ShopMain.php
@@ -29,9 +29,9 @@ class ShopMain extends ShopMain_parent
      *
      * @return bool
      */
-    public function canCreateShop($shopId, $shop)
+    public function checkCreateShop($shopId, $shop)
     {
-        return parent::canCreateShop($shopId, $shop);
+        return $this->canCreateShop($shopId, $shop);
     }
 
     /**
@@ -41,8 +41,8 @@ class ShopMain extends ShopMain_parent
      * @param \OxidEsales\Eshop\Application\Model\Shop $shop
      * @param string                                   $shopId
      */
-    public function updateShopInformation($config, $shop, $shopId)
+    public function updateShopInfo($config, $shop, $shopId)
     {
-        parent::updateShopInformation($config, $shop, $shopId);
+        $this->updateShopInformation($config, $shop, $shopId);
     }
 }

--- a/Controller/Admin/ShopMain.php
+++ b/Controller/Admin/ShopMain.php
@@ -16,12 +16,10 @@
 
 namespace OxidProfessionalServices\ModulesConfig\Controller\Admin;
 
-use OxidEsales\Eshop\Application\Controller\Admin\ShopMain as ShopMainCore;
-
 /**
  * ShopMain.
  */
-class ShopMain extends ShopMainCore
+class ShopMain extends ShopMain_parent
 {
     /**
      * Check if Shop can be created.

--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -32,7 +32,7 @@ use OxidProfessionalServices\OxidConsole\Core\ShopConfig;
 use OxidEsales\Eshop\Application\Controller\Admin\ShopLicense;
 use OxidEsales\Eshop\Core\Registry;
 use Symfony\Component\Console\Logger\ConsoleLogger;
-use OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain;
+use OxidEsales\Eshop\Application\Controller\Admin\ShopMain;
 use OxidEsales\Facts\Facts;
 use OxidEsales\Eshop\Application\Model\Shop;
 

--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -285,11 +285,11 @@ class ConfigImport extends CommandBase
                 $oShop->assign($parameters);
                 $oShop->setLanguage($shopLanguageId);
 
-                $canCreateShop = $shopMain->canCreateShop($sShopId, $oShop, $config);
+                $canCreateShop = $shopMain->checkCreateShop($sShopId, $oShop);
                 if ($canCreateShop) {
                     try {
                         $oShop->save();
-                        $shopMain->updateShopInformation($config, $oShop, $sShopId);
+                        $shopMain->updateShopInfo($config, $oShop, $sShopId);
                         Registry::getSession()->setVariable("actshop", $sShopId);
                     } catch (\Exception $exception) {
                         $this->logger->error(

--- a/metadata.php
+++ b/metadata.php
@@ -47,6 +47,7 @@ $aModule = [
     'extend'      => [],
     'controllers' => [
         'admin_oxpsmodulesconfigdashboard'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\Dashboard::class,
+        'shop_main'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain::class,
     ],
     'templates'   => [
         'admin_oxpsmodulesconfigdashboard.tpl' => 'oxps/modulesconfig/views/admin/admin_oxpsmodulesconfigdashboard.tpl',

--- a/metadata.php
+++ b/metadata.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of OXID Module Configuration Im-/Exporter module.
  *
@@ -24,6 +25,9 @@
  * @copyright (C] OXID eSales AG 2003-2014
  */
 
+use OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain;
+use OxidProfessionalServices\ModulesConfig\Controller\Admin\Dashboard;
+
 /**
  * Metadata version
  */
@@ -45,10 +49,10 @@ $aModule = [
     'url'         => 'http://www.oxid-esales.com',
     'email'       => 'info@oxid-esales.com',
     'extend'      => [
-        'shop_main'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain::class,
+        \OxidEsales\Eshop\Application\Controller\Admin\ShopMain::class  => ShopMain::class,
     ],
     'controllers' => [
-        'admin_oxpsmodulesconfigdashboard'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\Dashboard::class,
+        'admin_oxpsmodulesconfigdashboard'  => Dashboard::class,
     ],
     'templates'   => [
         'admin_oxpsmodulesconfigdashboard.tpl' => 'oxps/modulesconfig/views/admin/admin_oxpsmodulesconfigdashboard.tpl',

--- a/metadata.php
+++ b/metadata.php
@@ -44,10 +44,11 @@ $aModule = [
     'author'      => 'OXID Professional Services',
     'url'         => 'http://www.oxid-esales.com',
     'email'       => 'info@oxid-esales.com',
-    'extend'      => [],
+    'extend'      => [
+        'shop_main'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain::class,
+    ],
     'controllers' => [
         'admin_oxpsmodulesconfigdashboard'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\Dashboard::class,
-        'shop_main'  => OxidProfessionalServices\ModulesConfig\Controller\Admin\ShopMain::class,
     ],
     'templates'   => [
         'admin_oxpsmodulesconfigdashboard.tpl' => 'oxps/modulesconfig/views/admin/admin_oxpsmodulesconfigdashboard.tpl',


### PR DESCRIPTION
We have noticed some issues with OXID Shop 6.2.X
**Issues**:
1. Config import is not enabling a module if it's deactivated in DB. 
2. Config import is not creating sub-shops through configuration files. 

**Changes**:
1. Checking whether module is already active before deactivating the module. 

> $oModuleStateFixer->deactivate($oModule)

2. Creating sub-shops through defined configuration files.

**TODO** 
1. Need to test of Shop 6.1 (Currently checks are failing for it)
2. Add some more UT test cases

