### PR TITLE
Harden filternestedExcludes against $values without 'module' key

### DIFF
--- a/Core/ConfigExport.php
+++ b/Core/ConfigExport.php
@@ -118,6 +118,9 @@ class ConfigExport extends CommandBase
     protected function filternestedExcludes($values){
         $excludeDeep = $this->aConfiguration['excludeDeep'];
         $moduleValues = &$values['module'];
+        if (!is_array($moduleValues)) {
+            return $values;
+        }
         foreach ($moduleValues as $moduleId => &$moduleSettings) {
             foreach ($moduleSettings as $sVarName => &$aVarValue) {
                 if (is_array($aVarValue)) {


### PR DESCRIPTION
When getEnvironmentSpecificConfigurationValues() method is called, the
filternestedExcludes method is called from getConfigValues() method with an
array as argument which does not contain a 'module' key.

This commit avoid a warning message.